### PR TITLE
fix: fix portal permissions

### DIFF
--- a/io.github.antimicrox.antimicrox.yml
+++ b/io.github.antimicrox.antimicrox.yml
@@ -12,7 +12,9 @@ finish-args:
   - --socket=x11
   # Gamepads
   - --device=all
-
+  # Fixes https://github.com/AntiMicroX/antimicrox/issues/70 until
+  # https://github.com/flatpak/xdg-desktop-portal-gtk/issues/191 is fixed
+  - --filesystem=home
 
 modules:
   - name: antimicrox


### PR DESCRIPTION
With no `filesystem=home` access, the files are sometimes saved as a hidden file with no extension. This is due to https://github.com/flatpak/xdg-desktop-portal-gtk/issues/191.

This fixes https://github.com/AntiMicroX/antimicrox/issues/70