### PR TITLE
Drop org.kde.* own-name

### DIFF
--- a/io.github.antimicrox.antimicrox.yml
+++ b/io.github.antimicrox.antimicrox.yml
@@ -6,7 +6,6 @@ command: antimicrox
 finish-args:
   # KDE Plasma tray icon
   - --talk-name=org.kde.StatusNotifierWatcher
-  - --own-name=org.kde.*
   # X11 + XShm access
   - --share=ipc
   - --socket=x11


### PR DESCRIPTION
This is no longer required with any supported runtimes, the issue was fixed in Qt

https://docs.flatpak.org/en/latest/desktop-integration.html#statusnotifier

> Most implementations of StatusNotifer have dropped this requirement

https://github.com/flathub/flatpak-builder-lint/issues/ 66#issuecomment-1386033025