### PR TITLE
Revert "Bump runtime wersion to 6.8"

### DIFF
--- a/io.github.antimicrox.antimicrox.yml
+++ b/io.github.antimicrox.antimicrox.yml
@@ -1,6 +1,6 @@
 app-id: io.github.antimicrox.antimicrox
 runtime: org.kde.Platform
-runtime-version: '6.8'
+runtime-version: '5.15-24.08'
 sdk: org.kde.Sdk
 command: antimicrox
 finish-args:


### PR DESCRIPTION
This reverts commit e398eb40cb64136a919eb58dddf88d07d05b9415.

It may help with: https://github.com/AntiMicroX/antimicrox/issues/1142