### PR TITLE
Enable X11 and Wayland at once

### DIFF
--- a/io.github.antimicrox.antimicrox.yml
+++ b/io.github.antimicrox.antimicrox.yml
@@ -8,7 +8,7 @@ finish-args:
   - --talk-name=org.kde.StatusNotifierWatcher
   # X11 + XShm access
   - --share=ipc
-  - --socket=fallback-x11
+  - --socket=x11
   - --socket=wayland
   # Gamepads
   - --device=all


### PR DESCRIPTION
Access to both Wayland and X11 is required for proper button mapping.

Linked with PR: https://github.com/AntiMicroX/antimicrox/pull/1257

Closes: https://github.com/AntiMicroX/antimicrox/issues/1201