### PR TITLE
Disable X11 code

### DIFF
--- a/io.github.antimicrox.antimicrox.yml
+++ b/io.github.antimicrox.antimicrox.yml
@@ -8,7 +8,6 @@ finish-args:
   - --talk-name=org.kde.StatusNotifierWatcher
   # X11 + XShm access
   - --share=ipc
-  - --socket=fallback-x11
   - --socket=wayland
   # Gamepads
   - --device=all
@@ -22,6 +21,8 @@ modules:
     config-opts:
       - -DANTIMICROX_PKG_VERSION=flatpak
       - -DINSTALL_UINPUT_UDEV_RULES=OFF
+      - -DWITH_XTEST=OFF
+      - -DWITH_X11=OFF
     sources:
       - type: git
         url: https://github.com/AntiMicroX/antimicrox.git

--- a/io.github.antimicrox.antimicrox.yml
+++ b/io.github.antimicrox.antimicrox.yml
@@ -9,6 +9,7 @@ finish-args:
   # X11 + XShm access
   - --share=ipc
   - --socket=wayland
+  - --socket=fallback-x11
   # Gamepads
   - --device=all
   # Fixes https://github.com/AntiMicroX/antimicrox/issues/70 until


### PR DESCRIPTION
Remove fallback-x11 socket and disable X11 and XTEST options.


Linked with PR: https://github.com/AntiMicroX/antimicrox/pull/1257 and https://github.com/flathub/io.github.antimicrox.antimicrox/pull/35

Closes: https://github.com/AntiMicroX/antimicrox/issues/1201
